### PR TITLE
[actions] update steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: run dev container
         uses: devcontainers/ci@v0.3
@@ -28,7 +28,7 @@ jobs:
             ./gradlew assembleRelease
 
       - name: archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: outputs
           path: Native/app/build/outputs


### PR DESCRIPTION
Should fix warnings:

    Node.js 16 actions are deprecated. Please update the following actions
    to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v2. For
    more information see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

    The following actions uses node12 which is deprecated and will be forced
    to run on node16: actions/upload-artifact@v2. For more info:
    https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/