### PR TITLE
[actions] update steps (#7)

### DIFF
--- a/DotNet/libdotnet.csproj
+++ b/DotNet/libdotnet.csproj
@@ -45,4 +45,6 @@
     <Copy SourceFiles="@(_FilesToCopy)" DestinationFolder="$(_NativeFolder)" />
   </Target>
 
+  <Import Project="libdotnet.targets" />
+
 </Project>

--- a/DotNet/libdotnet.targets
+++ b/DotNet/libdotnet.targets
@@ -1,0 +1,34 @@
+<Project>
+  <PropertyGroup>
+    <_NdkSysrootAbi Condition=" '$(RuntimeIdentifier)' == 'linux-bionic-arm64' ">aarch64-linux-android</_NdkSysrootAbi>
+    <_NdkClangPrefix Condition=" '$(RuntimeIdentifier)' == 'linux-bionic-arm64' ">aarch64-linux-android21-</_NdkClangPrefix>
+    <_NdkPrebuiltAbi Condition=" '$(NETCoreSdkRuntimeIdentifier)' == 'osx-x64' ">darwin-x86_64</_NdkPrebuiltAbi>
+    <_NdkSysrootDir>$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/sysroot/usr/lib/$(_NdkSysrootAbi)</_NdkSysrootDir>
+    <_NdkBinDir>$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/bin</_NdkBinDir>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('linux-bionic'))">
+    <LinkStandardCPlusPlusLibrary>true</LinkStandardCPlusPlusLibrary>
+    <CppCompilerAndLinker>$(_NdkBinDir)/$(_NdkClangPrefix)clang++</CppCompilerAndLinker>
+    <ObjCopyName>$(_NdkBinDir)/llvm-objcopy</ObjCopyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux-bionic'))">
+    <LinkerArg Include="-Wl,--defsym,_init=__libc_init" />
+    <LinkerArg Include="-Wl,--defsym,_fini=__libc_fini" />
+    <LinkerArg Include="-L &quot;$(_NdkSysrootDir)&quot;" />
+    <NativeSystemLibrary Include="c" />
+  </ItemGroup>
+
+  <Target Name="_ValidateEnvironment"
+      BeforeTargets="Build">
+    <Error
+        Condition=" '$(ANDROID_NDK_HOME)' == '' Or !Exists($(ANDROID_NDK_HOME)) "
+        Text="Set the %24ANDROID_NDK_HOME environment variable to the path of the Android NDK."
+     />
+    <Error
+        Condition=" !Exists($(_NdkSysrootDir))"
+        Text="NDK 'sysroot' dir `$(_NdkSysrootDir)` does not exist. You're on your own."
+    />
+  </Target>
+</Project>


### PR DESCRIPTION
Should fix warnings:

    Node.js 16 actions are deprecated. Please update the following actions
    to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v2. For
    more information see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

    The following actions uses node12 which is deprecated and will be forced
    to run on node16: actions/upload-artifact@v2. For more info:
    https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/