### PR TITLE
Fix macOS host + linux-bionic-arm64 target cross-compile build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/postCreateCommand.sh",
 
 	"remoteEnv": {
-		"PATH": "${containerEnv:ANDROID_HOME}/ndk/23.2.8568313/toolchains/llvm/prebuilt/linux-x86_64/bin/:${containerEnv:PATH}"
+		"PATH": "${containerEnv:ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/:${containerEnv:PATH}"
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
 
 	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/postCreateCommand.sh",
 
+	"remoteEnv": {
+		"ANDROID_NDK_HOME": "${containerEnv:ANDROID_HOME}/ndk/23.2.8568313/"
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/postCreateCommand.sh",
 
 	"remoteEnv": {
-		"ANDROID_NDK_HOME": "${containerEnv:ANDROID_HOME}/ndk/23.2.8568313/"
+		"ANDROID_NDK_HOME": "${containerEnv:ANDROID_HOME}/ndk/23.2.8568313"
 	},
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,6 @@
 
 	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/postCreateCommand.sh",
 
-	"remoteEnv": {
-		"PATH": "${containerEnv:ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/:${containerEnv:PATH}"
-	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,6 +3,3 @@
 echo "ANDROID_HOME=$ANDROID_HOME"
 
 yes | sudo $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;23.2.8568313" "cmake;3.22.1"
-
-export "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/23.2.8568313"
-echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,3 +3,6 @@
 echo "ANDROID_HOME=$ANDROID_HOME"
 
 yes | sudo $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;23.2.8568313" "cmake;3.22.1"
+
+export "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/23.2.8568313"
+echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME"

--- a/DotNet/libdotnet.csproj
+++ b/DotNet/libdotnet.csproj
@@ -45,4 +45,6 @@
     <Copy SourceFiles="@(_FilesToCopy)" DestinationFolder="$(_NativeFolder)" />
   </Target>
 
+  <Import Project="libdotnet.targets" />
+
 </Project>

--- a/DotNet/libdotnet.targets
+++ b/DotNet/libdotnet.targets
@@ -3,6 +3,7 @@
     <_NdkSysrootAbi Condition=" '$(RuntimeIdentifier)' == 'linux-bionic-arm64' ">aarch64-linux-android</_NdkSysrootAbi>
     <_NdkClangPrefix Condition=" '$(RuntimeIdentifier)' == 'linux-bionic-arm64' ">aarch64-linux-android21-</_NdkClangPrefix>
     <_NdkPrebuiltAbi Condition=" '$(NETCoreSdkRuntimeIdentifier)' == 'osx-x64' ">darwin-x86_64</_NdkPrebuiltAbi>
+    <_NdkPrebuiltAbi Condition=" '$(NETCoreSdkRuntimeIdentifier)' == 'linux-x64' ">linux-x86_64</_NdkPrebuiltAbi>
     <_NdkSysrootDir>$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/sysroot/usr/lib/$(_NdkSysrootAbi)</_NdkSysrootDir>
     <_NdkBinDir>$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/bin</_NdkBinDir>
   </PropertyGroup>

--- a/DotNet/libdotnet.targets
+++ b/DotNet/libdotnet.targets
@@ -1,0 +1,34 @@
+<Project>
+  <PropertyGroup>
+    <_NdkSysrootAbi Condition=" '$(RuntimeIdentifier)' == 'linux-bionic-arm64' ">aarch64-linux-android</_NdkSysrootAbi>
+    <_NdkClangPrefix Condition=" '$(RuntimeIdentifier)' == 'linux-bionic-arm64' ">aarch64-linux-android21-</_NdkClangPrefix>
+    <_NdkPrebuiltAbi Condition=" '$(NETCoreSdkRuntimeIdentifier)' == 'osx-x64' ">darwin-x86_64</_NdkPrebuiltAbi>
+    <_NdkSysrootDir>$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/sysroot/usr/lib/$(_NdkSysrootAbi)</_NdkSysrootDir>
+    <_NdkBinDir>$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(_NdkPrebuiltAbi)/bin</_NdkBinDir>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('linux-bionic'))">
+    <LinkStandardCPlusPlusLibrary>true</LinkStandardCPlusPlusLibrary>
+    <CppCompilerAndLinker>$(_NdkBinDir)/$(_NdkClangPrefix)clang++</CppCompilerAndLinker>
+    <ObjCopyName>$(_NdkBinDir)/llvm-objcopy</ObjCopyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux-bionic'))">
+    <LinkerArg Include="-Wl,--defsym,_init=__libc_init" />
+    <LinkerArg Include="-Wl,--defsym,_fini=__libc_fini" />
+    <LinkerArg Include="-L &quot;$(_NdkSysrootDir)&quot;" />
+    <NativeSystemLibrary Include="c" />
+  </ItemGroup>
+
+  <Target Name="_ValidateEnvironment"
+      BeforeTargets="Build">
+    <Error
+        Condition=" '$(ANDROID_NDK_HOME)' == '' Or !Exists($(ANDROID_NDK_HOME)) "
+        Text="Set the %24ANDROID_NDK_HOME environment variable to the path of the Android NDK."
+     />
+    <Error
+        Condition=" !Exists($(_NdkSysrootDir))"
+        Text="NDK 'sysroot' dir `$(_NdkSysrootDir)` does not exist. You're on your own."
+    />
+  </Target>
+</Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/101727

Previously, trying to use `dotnet publish` from a macOS host would result in obscure build failures, e.g.

	% dotnet publish -c Release
	…
	clang : error : invalid linker name in argument '-fuse-ld=lld'

Apply the workaround from dotnet/runtime#101727 to workaround this. The `$(ANDROID_NDK_HOME)` environment variable requuired:

	# we're all xamarin-android devs here, right? ;-)
	% export ANDROID_NDK_HOME=$HOME/android-toolchain/ndk
	% dotnet publish -c Release
	# Creates DotNet/bin/Release/net8.0/linux-bionic-arm64/publish/libdotnet.so